### PR TITLE
Fix XSS vulnerability.

### DIFF
--- a/freewall.js
+++ b/freewall.js
@@ -1,4 +1,3 @@
-
 // created by Minh Nguyen;
 // version 1.04;
 
@@ -48,7 +47,7 @@
             var block = null;
             var gutterX = runtime.gutterX;
             var gutterY = runtime.gutterY;
-            var fixSize = eval($item.attr('data-fixSize'));
+            var fixSize = $item.data('fixSize');
             var blockId = runtime.lastId++ + '-' + this.totalGrid;
             
             //ignore dragging block;


### PR DESCRIPTION
Technically, if freewall is used on a page where users can contribute content, especially HTML, if a user knows the site is running freewall he/she can insert any arbitrary javascript in the following way:

``` html
<div data-fixSize="alert('xss!')"></div>
```

This can easily be fixed by using `$.fn.data()`, which is available in both jQuery and Zepto. It converts "true", "false", and "null" to the correct types, and numbers to the Number type, allowing the conditional on L76 to work.

See [$.fn#data](http://zeptojs.com/#data).
