### PR TITLE
Setup ignored folders/files for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,5 +15,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/kombai/freewall.git"
-  }
+  },
+  "ignore": [
+    "example",
+    "i",
+    "*.html"
+  ]
 }


### PR DESCRIPTION
It's not necessary for bower to download either the /examples folder or the /i folder. To keep bower lighter and making bower installations faster I defined the ignores on bower.json. That coupled with a version bump and the accompanying version tag should be enough to make using freewall with bower easier.
