### PR TITLE
Constructor name "new freewall" don't pass on jshint tests

### DIFF
--- a/404.html
+++ b/404.html
@@ -48,7 +48,7 @@
 			}
 			$("#freewall").html(html);
 			
-			var wall = new freewall("#freewall");
+			var wall = new Freewall("#freewall");
 			wall.reset({
 				selector: '.cell',
 				animate: true,

--- a/example/append-more.html
+++ b/example/append-more.html
@@ -64,7 +64,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: true,

--- a/example/centering-grid.html
+++ b/example/centering-grid.html
@@ -56,7 +56,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: true,

--- a/example/css-animate.html
+++ b/example/css-animate.html
@@ -79,7 +79,7 @@
 			}
 			$("#freewall").html(html);
 			
-			var wall = new freewall("#freewall");
+			var wall = new Freewall("#freewall");
 			wall.reset({
 				selector: '.cell',
 				animate: false,

--- a/example/demo-filter.html
+++ b/example/demo-filter.html
@@ -86,7 +86,7 @@
 			$("#freewall").html(html);
 			
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: true,

--- a/example/demo-sort.html
+++ b/example/demo-sort.html
@@ -60,7 +60,7 @@
 			$("#freewall").html(html);
 			
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: true,

--- a/example/direction.html
+++ b/example/direction.html
@@ -57,7 +57,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: true,

--- a/example/draggable.html
+++ b/example/draggable.html
@@ -77,7 +77,7 @@
 			}
 			
 			
-			var wall = new freewall("#freewall");
+			var wall = new Freewall("#freewall");
 			wall.reset({
 				draggable: true,
 				selector: '.cell',

--- a/example/filter+fixpos.html
+++ b/example/filter+fixpos.html
@@ -86,7 +86,7 @@
 		<script type="text/javascript">
 			
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					draggable: true,

--- a/example/fit-height.html
+++ b/example/fit-height.html
@@ -70,7 +70,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					cellW: 160,

--- a/example/fit-zone.html
+++ b/example/fit-zone.html
@@ -96,7 +96,7 @@
 			
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: false,

--- a/example/fix-position.html
+++ b/example/fix-position.html
@@ -73,7 +73,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: true,

--- a/example/fixsize-test.html
+++ b/example/fixsize-test.html
@@ -59,7 +59,7 @@
 
 
 		<script type="text/javascript">
-			var wall = new freewall('.freewall');
+			var wall = new Freewall('.freewall');
 			var start = new Date().getTime();
 			wall.reset({
 	            selector: '.brick',

--- a/example/flex-grid.html
+++ b/example/flex-grid.html
@@ -40,7 +40,7 @@
 			}
 			$("#freewall").html(html);
 			
-			var wall = new freewall("#freewall");
+			var wall = new Freewall("#freewall");
 			wall.reset({
 				selector: '.brick',
 				animate: true,

--- a/example/for-zepto.html
+++ b/example/for-zepto.html
@@ -111,7 +111,7 @@
 
 			$(function() {
 				$(".free-wall").each(function() {
-					var wall = new freewall(this);
+					var wall = new Freewall(this);
 					wall.reset({
 						selector: '.size320',
 						cellW: 320,

--- a/example/getting-started.html
+++ b/example/getting-started.html
@@ -29,7 +29,7 @@
   </div>
   <script>
     $(function() {
-      var wall = new freewall("#container");
+      var wall = new Freewall("#container");
       wall.fitWidth();
     });
   </script>

--- a/example/grid-layout.html
+++ b/example/grid-layout.html
@@ -35,7 +35,7 @@
 			}
 			$("#freewall").html(html);
 			
-			var wall = new freewall("#freewall");
+			var wall = new Freewall("#freewall");
 			wall.reset({
 				selector: '.cell',
 				animate: true,

--- a/example/gutter-auto.html
+++ b/example/gutter-auto.html
@@ -56,7 +56,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.size22',
 					cellW: 320,

--- a/example/hide-block-test.html
+++ b/example/hide-block-test.html
@@ -25,7 +25,7 @@
 		<div id="freewall" class="free-wall"></div>
 
 		<script type="text/javascript">
-			var wall = new freewall('.free-wall');
+			var wall = new Freewall('.free-wall');
 			var temp = "<div class='cell' style='width:{width}px; height: {height}px; background-color: {color}'><div class='cover'></div></div>";
 			var colour = ["#DAA520", "#CD950C",	"#EEB422", "#CD9B1D"];
 

--- a/example/image-layout.html
+++ b/example/image-layout.html
@@ -35,7 +35,7 @@
 			}
 			$("#freewall").html(html);
 			
-			var wall = new freewall("#freewall");
+			var wall = new Freewall("#freewall");
 			wall.reset({
 				selector: '.cell',
 				animate: true,

--- a/example/js/index.js
+++ b/example/js/index.js
@@ -42,7 +42,7 @@
 		},
 		layout: function() {
 			var lwidth = $(window).width();
-			wall = new freewall('.free-wall');
+			wall = new Freewall('.free-wall');
 			
 			wall.reset({
 				selector: '> div',
@@ -159,7 +159,7 @@
 			});
 		},
 		drillhole: function() {
-			var wall = new freewall('.free-wall-logo');
+			var wall = new Freewall('.free-wall-logo');
 			var temp = "<div class='cell' style='width:{width}px; height: {height}px; background-color: {color}'><div class='cover'></div></div>";
 			var colour = [
 				"#DAA520",

--- a/example/live-size.html
+++ b/example/live-size.html
@@ -49,7 +49,7 @@
             }
 
 
-            var wall = new freewall("#freewall");
+            var wall = new Freewall("#freewall");
             wall.reset({
                 selector: 'article',
                 animate: true,

--- a/example/metro-style.html
+++ b/example/metro-style.html
@@ -143,7 +143,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.level1',
 					cellW: 320,

--- a/example/nested-grid.html
+++ b/example/nested-grid.html
@@ -122,7 +122,7 @@
 
 			$(function() {
 				$(".free-wall").each(function() {
-					var wall = new freewall(this);
+					var wall = new Freewall(this);
 					wall.reset({
 						selector: '.size320',
 						cellW: 320,

--- a/example/pinterest-layout.html
+++ b/example/pinterest-layout.html
@@ -387,7 +387,7 @@
 		</div>
 		
 		<script type="text/javascript">
-			var wall = new freewall("#freewall");
+			var wall = new Freewall("#freewall");
 			wall.reset({
 				selector: '.brick',
 				animate: true,

--- a/example/prepend-example.html
+++ b/example/prepend-example.html
@@ -64,7 +64,7 @@
 			});
 
 			$(function() {
-				var wall = new freewall("#freewall");
+				var wall = new Freewall("#freewall");
 				wall.reset({
 					selector: '.brick',
 					animate: true,

--- a/example/render-layout-test.html
+++ b/example/render-layout-test.html
@@ -24,7 +24,7 @@
 		<div id="freewall" class="free-wall"></div>
 
 		<script type="text/javascript">
-			var wall = new freewall('.free-wall');
+			var wall = new Freewall('.free-wall');
 			var temp = "<div class='cell' style='width:{width}px; height: {height}px; background-color: {color}'><div class='cover'></div></div>";
 			var colour = ["#DAA520", "#CD950C",	"#EEB422", "#CD9B1D"];
 

--- a/example/several-instances.html
+++ b/example/several-instances.html
@@ -99,7 +99,7 @@
 
 			$(function() {
 				$(".free-wall").each(function() {
-					var wall = new freewall(this);
+					var wall = new Freewall(this);
 					wall.reset({
 						selector: '.size320',
 						cellW: 320,

--- a/freewall.js
+++ b/freewall.js
@@ -288,7 +288,7 @@
             var block = runtime.blocks[item.id];
             
             if (block) {
-                innerWall = new freewall($item);
+                innerWall = new Freewall($item);
                 innerWall.reset({
                     cellH: cellH,
                     cellW: cellW,
@@ -744,7 +744,7 @@
 
 
 
-    window.freewall = function(selector) {
+    window.Freewall = function(selector) {
         
         var container = $(selector);
         if (container.css('position') == 'static') {
@@ -1287,11 +1287,11 @@
     add default setting;
     example:
 
-        freewall.addConfig({
+        Freewall.addConfig({
             offsetLeft: 0
         });
     */
-    freewall.addConfig = function(newConfig) {
+    Freewall.addConfig = function(newConfig) {
         // add default setting;
         $.extend(layoutManager.defaultConfig, newConfig);    
     };
@@ -1301,13 +1301,13 @@
     support create new arrange algorithm;
     example:
 
-        freewall.createEngine({
+        Freewall.createEngine({
             slice: function(items, setting) {
                 // slice engine;
             }
         });
     */
-    freewall.createEngine = function(engineData) {
+    Freewall.createEngine = function(engineData) {
         // create new engine;
         $.extend(engine, engineData);
     };
@@ -1316,14 +1316,14 @@
     support create new plugin;
     example:
         
-        freewall.createPlugin({
+        Freewall.createPlugin({
             centering: function(setting, container) {
                 console.log(this);
                 console.log(setting);
             }
         })l
     */
-    freewall.createPlugin = function(pluginData) {
+    Freewall.createPlugin = function(pluginData) {
         // register new plugin;
         $.extend(layoutManager.plugin, pluginData);
     };
@@ -1332,9 +1332,9 @@
     support access helper function;
     example:
 
-        freewall.getMethod('setBlock')(block, setting);
+        Freewall.getMethod('setBlock')(block, setting);
     */
-    freewall.getMethod = function(method) {
+    Freewall.getMethod = function(method) {
         // get helper method;
         return layoutManager[method];
     };

--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
   &lt;/div&gt;
   &lt;script&gt;
     $(function() {
-      var wall = new freewall("#container");
+      var wall = new Freewall("#container");
       wall.fitWidth();
     });
   &lt;/script&gt;
@@ -249,7 +249,7 @@
 								<h3> Example </h3>
 									<pre>
 										<code>
-var wall = new freewall('.free-wall');
+var wall = new Freewall('.free-wall');
 wall.reset({
   selector: '.brick',
   cellW: function(width) {
@@ -320,7 +320,7 @@ wall.reset({
 								<h3> Example </h3>
 								<pre>
 									<code>
-var wall = new freewall('.free-wall');
+var wall = new Freewall('.free-wall');
 wall.reset({
   selector: '.brick',
   animate: true,
@@ -395,7 +395,7 @@ wall.reset({
 								<h3> Example </h3>
 								<pre>
 									<code>
-var wall = new freewall('.free-wall');
+var wall = new Freewall('.free-wall');
 wall.reset({
   selector: '.brick',
   onResize: function() {
@@ -501,7 +501,7 @@ wall.reset({
 								<h5> Example </h5>
 								<pre>
 									<code>
-var wall = new freewall('.free-wall');
+var wall = new Freewall('.free-wall');
 var dna = $(".free-wall .flex-layout");
 wall.unsetFilter();
 wall.fixSize({
@@ -527,7 +527,7 @@ wall.fitWidth();
 								<h5> Example </h5>
 								<pre>
 									<code>
-var ewall = new freewall(demo);
+var ewall = new Freewall(demo);
 var demo = $(".example");
 ewall.reset({
   selector: '.cell',

--- a/plugin/centering.js
+++ b/plugin/centering.js
@@ -3,7 +3,7 @@
 // centering plugin;
 
 // to make grid center in container;
-freewall.createPlugin({
+Freewall.createPlugin({
 	centering: function(setting, container) {
 		var runtime = setting.runtime;
 		this.addCustomEvent("onGridArrange", function(setting) {


### PR DESCRIPTION
The constructor "new freewall(string)" don't pass on jshint tests because the right way to instantiate objects in JS is using a initial capital letter, as "new Freewall(string)".

Using the actual method will make gulp/grunt jshint throw an error and then stop the process (in most cases). I changed all the references to Freewall, so it is working now.